### PR TITLE
Refs #4: Workaround invalid path generation in hsc2hs/inline-c on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 src/**/*.c
 .cabal-sandbox
 .stack-work
+srcLanguageCClangInternalFFI.c

--- a/clang-pure.cabal
+++ b/clang-pure.cabal
@@ -53,7 +53,10 @@ library
   hs-source-dirs:      src/
   build-tools:         hsc2hs
   default-language:    Haskell2010
-  c-sources:           src/Language/C/Clang/Internal/FFI.c
+  if os(windows)
+    c-sources:         srcLanguageCClangInternalFFI.c
+  else
+    c-sources:         src/Language/C/Clang/Internal/FFI.c
   include-dirs:        cbits/
   cc-options:          -Wall
   extra-libraries:     clang


### PR DESCRIPTION
Since this is likely a bug in one of hsc2hs, inline-c or Template Haskell, it may take a while for a fix to be available. This temporary workaround will allow clang-pure to reference the inline-c-generated source file from its current, invalid location when building under Windows.
