### PR TITLE
Detect location of libclang library and headers and set include-dirs etc.

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,70 @@
+# Development guide <small>[&#8617;][readme]</small>
+
+## Install prerequisites
+
+You'll need a recent version of [LLVM/Clang][llvm]. clang-pure has been tested
+with LLVM version [3.8.1][llvm381].
+
+### Linux
+
+Install the LLVM version [3.8.1][llvm381] package or install from your distro's
+official repositories, if the package version is recent enough. For example, on
+Ubuntu:
+
+```bash
+$ sudo apt-get install libclang-dev
+```
+
+Note that the pre-built versions of LLVM packaged for Centos are typically too
+old and so you'll need to install LLVM version [3.8.1][llvm381] or build it
+from source.
+
+### Windows
+
+Install the LLVM version [3.8.1][llvm381] package and install to the default
+location, which is typically `%PROGRAMFILES%\LLVM`.
+
+### Mac OS X
+
+Build LLVM version [3.8.1][llvm381] from source or install using
+[Homebrew][brew] (easiest):
+
+```bash
+$ brew tap homebrew/versions
+$ brew install llvm38
+```
+
+## Building
+
+Build using [Stack][stack] from the repository root:
+
+```bash
+$ stack setup
+$ stack build
+```
+
+If the setup script is unable to detect your LLVM/libclang library paths
+automatically, you can override the default search location using the
+`CLANG_PURE_LLVM_DIR` and then re-run the build.
+
+On Linux or Mac OS X:
+
+```bash
+$ CLANG_PURE_LLVM_DIR=/path/to/llvm stack build
+```
+
+On Windows:
+
+```cmd
+> set CLANG_PURE_LLVM_DIR=C:\Path\To\LLVM
+> stack build
+```
+
+The default search location for libraries and include directories is `/usr`
+under Linux and Mac OS X and `%PROGRAMFILES%\LLVM` on Windows.
+
+[brew]: http://brew.sh/
+[llvm]: http://llvm.org/
+[llvm381]: http://llvm.org/releases/download.html#3.8.1
+[readme]: README.md
+[stack]: https://haskellstack.org/

--- a/README.md
+++ b/README.md
@@ -28,4 +28,9 @@ main = do
     forM_ functionDecls (print . cursorSpelling)
 ```
 
+## Development
+
+[View development guide][building]
+
+[building]: DEV.md
 [libclang]: http://clang.llvm.org/doxygen/group__CINDEX.html

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,18 +1,123 @@
-{-
-Copyright 2014 Google Inc. All Rights Reserved.
+{-|
+Module      : Main
+Description : Setup script for clang-pure build
+Copyright   : (C) Richard Cook, 2016
+Licence     : Apache 2.0
+Maintainer  : rcook@rcook.org
+Stability   : experimental
+Portability : portable
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+This setup script adds a configuration hook to the build process to discover
+the LLVM library and include paths from the standard system-wide installation
+location or from an alternative location if overridden with the
+@CLANG_PURE_LLVM_DIR@ environment variable.
 -}
 
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Main (main) where
+
+import Control.Exception
+import Control.Monad
+#ifndef mingw32_HOST_OS
+import Data.Maybe
+#endif
+import Distribution.PackageDescription
 import Distribution.Simple
-main = defaultMain
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.Setup
+import System.Directory
+import System.Environment
+import System.FilePath
+import System.IO.Error
+
+data SetupException = SetupException String deriving Show
+
+instance Exception SetupException
+
+data LLVMPathInfo = LLVMPathInfo
+    { llvmLibraryDir :: FilePath
+    , llvmIncludeDir :: FilePath
+    }
+
+llvmDirEnvVarName :: String
+llvmDirEnvVarName = "CLANG_PURE_LLVM_DIR"
+
+libraryExtension :: String
+#ifdef mingw32_HOST_OS
+libraryExtension = ".dll"
+#elif darwin_HOST_OS
+libraryExtension = ".dylib"
+#else
+libraryExtension = ".so"
+#endif
+
+getRecursiveContents :: FilePath -> IO [FilePath]
+getRecursiveContents dir = do
+    allNames <- getDirectoryContents dir `catch` (\e -> if isPermissionError e then return [] else throw e)
+    let names = filter (`notElem` [".", ".."]) allNames
+    paths <- forM names $ \name -> do
+        let path = dir </> name
+        isDirectory <- doesDirectoryExist path
+        if isDirectory
+           then getRecursiveContents path
+           else return [path]
+    return (concat paths)
+
+findFileRecursive :: FilePath -> String -> IO FilePath
+findFileRecursive dir fileName = do
+    paths <- getRecursiveContents dir
+    let matches = filter (\p -> takeFileName p == fileName) paths
+    case matches of
+         [] -> throw $ SetupException ("Could not find " ++ fileName ++ " under " ++ dir)
+         firstMatch : _ -> return firstMatch
+
+getLLVMRootDir :: IO FilePath
+#ifdef mingw32_HOST_OS
+getLLVMRootDir = do
+    maybeOverride <- lookupEnv llvmDirEnvVarName
+    case maybeOverride of
+        Nothing -> do
+            programFilesDir <- getEnv "PROGRAMFILES"
+            return $ programFilesDir </> "LLVM"
+        Just llvmRootDir -> return llvmRootDir
+#else
+getLLVMRootDir = do
+    maybeOverride <- lookupEnv llvmDirEnvVarName
+    let llvmRootDir = fromMaybe "/usr" maybeOverride
+    return llvmRootDir
+#endif
+
+getLLVMPathInfo :: IO LLVMPathInfo
+getLLVMPathInfo = do
+    llvmRootDir <- getLLVMRootDir
+    libclangPath <- findFileRecursive llvmRootDir ("libclang" -<.> libraryExtension)
+    let libraryDir = takeDirectory libclangPath
+    indexHeaderPath <- findFileRecursive llvmRootDir "Index.h"
+    let includeDir = takeDirectory $ takeDirectory indexHeaderPath
+    return $ LLVMPathInfo libraryDir includeDir
+
+clangPureConfHook :: (GenericPackageDescription, HookedBuildInfo) -> ConfigFlags -> IO LocalBuildInfo
+clangPureConfHook (d, bi) flags = do
+    localBuildInfo <- confHook simpleUserHooks (d, bi) flags
+    let pd = localPkgDescr localBuildInfo
+        Just lib = library pd
+        lbi = libBuildInfo lib
+
+    LLVMPathInfo{..} <- getLLVMPathInfo
+
+    return localBuildInfo {
+        localPkgDescr = pd {
+            library = Just $ lib {
+                libBuildInfo = lbi
+                { includeDirs = llvmIncludeDir : includeDirs lbi
+                , extraLibDirs = llvmLibraryDir : extraLibDirs lbi
+                }
+            }
+        }
+    }
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks { confHook = clangPureConfHook }

--- a/clang-pure.cabal
+++ b/clang-pure.cabal
@@ -12,7 +12,7 @@ author:                Patrick Chilton
 maintainer:            chpatrick@gmail.com
 copyright:             Copyright 2014 Google Inc. All Rights Reserved.
 category:              Language
-build-type:            Simple
+build-type:            Custom
 -- extra-source-files:  
 cabal-version:         >=1.10
 extra-source-files:  cbits/utils.h


### PR DESCRIPTION
This adds setup-time auto-detection of libclang headers and libraries on Linux, Mac OS X and Windows. It also adds a new "development guide" with setup and build instructions.
