### PR TITLE
Added support for various type queries; updated ListStructs example

### DIFF
--- a/src/Language/C/Clang/Type.hs
+++ b/src/Language/C/Clang/Type.hs
@@ -16,6 +16,10 @@ limitations under the License.
 
 module Language.C.Clang.Type
   ( Type()
+  , typeArraySize
+  , typeCanonicalType
+  , typeElementType
+  , typeSizeOf
   , typeSpelling
   , typeKind
   , TypeKind(..)


### PR DESCRIPTION
This commit adds new Type functions in Language.C.Clang.Type. They allow obtaining complete layout information of more complicated structs than before the commit.

I'm not sure what naming convention you prefer for the new functions, but I decided to prefix them with 'type' to make it clear that they return something about a given type. If you have other thoughts, please let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chpatrick/clang-pure/9)
<!-- Reviewable:end -->
