### PR TITLE
Fixes for ghc-8.4.2

### DIFF
--- a/src/Language/C/Clang/Internal/Context.hs
+++ b/src/Language/C/Clang/Internal/Context.hs
@@ -17,7 +17,6 @@ limitations under the License.
 module Language.C.Clang.Internal.Context where
 
 import qualified Data.Map as M
-import Data.Monoid
 import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C

--- a/src/Language/C/Clang/Internal/Types.hs
+++ b/src/Language/C/Clang/Internal/Types.hs
@@ -17,6 +17,7 @@ limitations under the License.
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
 
 module Language.C.Clang.Internal.Types where
 


### PR DESCRIPTION
- Small fixes for ghc-8.4.2
- Monoid gives warning
- GADTs need extension

Building still fails with this error, but at least now we can get there:
`<command line>: does not exist: src/Language/C/Clang/Internal/FFI.c`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chpatrick/clang-pure/12)
<!-- Reviewable:end -->
