### PR TITLE
Expose all arguments of clang_createIndex and clang_parseTranslationUnit2

### DIFF
--- a/src/Language/C/Clang.hs
+++ b/src/Language/C/Clang.hs
@@ -18,7 +18,9 @@ module Language.C.Clang (
   module C,
   -- * Index
   ClangIndex(),
+  ClangIndexOption(..),
   createIndex,
+  createIndexWithOptions,
   -- * Utilities
   Clang(),
   ClangOrd(..)

--- a/src/Language/C/Clang/Internal/Context.hs
+++ b/src/Language/C/Clang/Internal/Context.hs
@@ -36,6 +36,7 @@ clangTypesTable = M.fromList
   , (C.TypeName "CXFile", [t| CXFile |])
   , (C.TypeName "CXType", [t| CXType |])
   , (C.TypeName "CXToken", [t| CXToken |])
+  , (C.Struct "CXUnsavedFile", [t| CXUnsavedFile |])
   ]
 
 clangCtx :: C.Context

--- a/src/Language/C/Clang/Internal/FFI.hsc
+++ b/src/Language/C/Clang/Internal/FFI.hsc
@@ -48,8 +48,15 @@ foreign import ccall "clang_disposeIndex"
   clang_disposeIndex :: Ptr CXIndexImpl -> Finalizer
 
 createIndex :: IO ClangIndex
-createIndex = do
-  idxp <- [C.exp| CXIndex { clang_createIndex(0, 1) } |]
+createIndex = createIndexWithOptions [ DisplayDiagnostics ]
+
+createIndexWithOptions :: [ ClangIndexOption ] -> IO ClangIndex
+createIndexWithOptions opts = do
+  let excludeDecl = fromBool $ ExcludeDeclarationsFromPCH `elem` opts
+      displayDiag = fromBool $ DisplayDiagnostics `elem` opts
+  idxp <- [C.exp| CXIndex {
+    clang_createIndex($(int excludeDecl), $(int displayDiag))
+    } |]
   ClangIndex <$> newRoot idxp (clang_disposeIndex idxp)
 
 foreign import ccall "clang_disposeTranslationUnit"

--- a/src/Language/C/Clang/Internal/Types.hs
+++ b/src/Language/C/Clang/Internal/Types.hs
@@ -21,8 +21,10 @@ limitations under the License.
 
 module Language.C.Clang.Internal.Types where
 
+import Data.ByteString (ByteString)
 import Data.Singletons.TH
 import Foreign
+import Foreign.C
 
 import Language.C.Clang.Internal.Refs
 
@@ -45,6 +47,26 @@ type instance RefOf TranslationUnit = CXTranslationUnitImpl
 type instance ParentOf TranslationUnit = ClangIndex
 newtype TranslationUnit = TranslationUnitRef (Node ClangIndex CXTranslationUnitImpl)
   deriving (Parent, Child, Clang)
+
+data CXUnsavedFile = CXUnsavedFile
+  { cxUnsavedFileName :: CString
+  , cxUnsavedFileContents :: CString
+  , cxUnsavedFileLength :: CULong
+  }
+
+type UnsavedFile = ( FilePath, ByteString )
+
+data TranslationUnitOption
+  = DetailedPreprocessingRecord
+  | Incomplete
+  | PrecompiledPreamble
+  | CacheCompletionResults
+  | ForSerialization
+  | CXXChainedPCH
+  | SkipFunctionBodies
+  | IncludeBriefCommentsInCodeCompletion
+  | CreatePreambleOnFirstParse
+    deriving (Eq, Ord, Show)
 
 instance Eq TranslationUnit where (==) = pointerEq
 

--- a/src/Language/C/Clang/Internal/Types.hs
+++ b/src/Language/C/Clang/Internal/Types.hs
@@ -32,6 +32,11 @@ type instance RefOf ClangIndex = CXIndexImpl
 newtype ClangIndex = ClangIndex (Root CXIndexImpl)
   deriving (Parent, Clang)
 
+data ClangIndexOption
+  = ExcludeDeclarationsFromPCH
+  | DisplayDiagnostics
+    deriving (Eq, Ord, Show)
+
 instance Eq ClangIndex where (==) = pointerEq
 
 data CXTranslationUnitImpl

--- a/src/Language/C/Clang/TranslationUnit.hs
+++ b/src/Language/C/Clang/TranslationUnit.hs
@@ -16,7 +16,10 @@ limitations under the License.
 
 module Language.C.Clang.TranslationUnit
   ( TranslationUnit()
+  , TranslationUnitOption(..)
+  , UnsavedFile
   , parseTranslationUnit
+  , parseTranslationUnitWithOptions
   )
 where
 


### PR DESCRIPTION
Hi @chpatrick,

This PR adds two new functions `createIndexWithOptions` and `parseTranslationUnitWithOptions` that support all arguments of libclang's `clang_createIndex` and `clang_parseTranslationUnit2`. Now you can write something like this:

```
let code = "int main(int argc, char **argv) { return 0; }"
idx <- createIndexWithOptions [DisplayDiagnostics]
tu <- parseTranslationUnitWithOptions idx "main.cpp" ["-Wall"] [("main.cpp", code)] [SkipFunctionBodies]
```

These additional options are useful to fine-tune Clang parser and process in-memory files.

I kept existing functions `createIndex` and `parseTranslationUnit` for backward compatibility but implemented them as shortcuts to `createIndexWithOptions` and `parseTranslationUnitWithOptions`.

Thanks in advance!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chpatrick/clang-pure/15)
<!-- Reviewable:end -->
