### PR TITLE
Update to use (separated) singletons-th.

### DIFF
--- a/clang-pure.cabal
+++ b/clang-pure.cabal
@@ -57,7 +57,8 @@ library
                        vector >= 0.10.12,
                        bytestring >= 0.10.6,
                        stm >= 2.4.4,
-                       singletons >= 2.0.1,
+                       singletons >= 3.0,
+                       singletons-th >=3.2,
                        microlens >= 0.4.2.1,
                        microlens-contra >= 0.1.0.1
   hs-source-dirs:      src/

--- a/src/Language/C/Clang/Cursor/Typed.hs
+++ b/src/Language/C/Clang/Cursor/Typed.hs
@@ -49,7 +49,7 @@ import           Data.Word
 import           Lens.Micro.Contra
 
 import qualified Language.C.Clang.Cursor as UT
-import           Language.C.Clang.Cursor ( cursorKind, Cursor, CursorKind(..) )
+import           Language.C.Clang.Cursor ( cursorKind )
 import           Language.C.Clang.Location
 import           Language.C.Clang.Internal.Types
 

--- a/src/Language/C/Clang/Internal/Context.hs
+++ b/src/Language/C/Clang/Internal/Context.hs
@@ -17,7 +17,6 @@ limitations under the License.
 module Language.C.Clang.Internal.Context where
 
 import qualified Data.Map as M
-import Data.Monoid ((<>))
 import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Context as C
 import qualified Language.C.Types as C

--- a/src/Language/C/Clang/Internal/Types.hs
+++ b/src/Language/C/Clang/Internal/Types.hs
@@ -18,6 +18,7 @@ limitations under the License.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 
 module Language.C.Clang.Internal.Types where
 


### PR DESCRIPTION
With these changes, clang-pure builds with GHC 9.2.7 without warnings. I've still only tested it with LLVM 9, not any later versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chpatrick/clang-pure/25)
<!-- Reviewable:end -->
