### PR TITLE
Fix build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+dist-newstyle/
 src/**/*.c
 .cabal-sandbox
 .stack-work

--- a/clang-pure.cabal
+++ b/clang-pure.cabal
@@ -44,6 +44,8 @@ library
                        GeneralizedNewtypeDeriving,
                        TemplateHaskell,
                        QuasiQuotes,
+                       StandaloneKindSignatures,
+                       TypeOperators,
                        OverloadedStrings,
                        LambdaCase,
                        NamedFieldPuns,
@@ -57,7 +59,8 @@ library
                        vector >= 0.10.12,
                        bytestring >= 0.10.6,
                        stm >= 2.4.4,
-                       singletons >= 2.0.1,
+                       singletons >= 3.0.3 && < 4,
+                       singletons-th >= 3.0 && < 4,
                        microlens >= 0.4.2.1,
                        microlens-contra >= 0.1.0.1
   hs-source-dirs:      src/

--- a/clang-pure.cabal
+++ b/clang-pure.cabal
@@ -65,7 +65,7 @@ library
   default-language:    Haskell2010
   include-dirs:        cbits/
   includes:            clang-c/Index.h
-  cc-options:          -Wall -Werror
+  cc-options:          -Wall
   extra-libraries:     clang
   ghc-options:         -Wall
   if impl(ghc >= 8.0.0)


### PR DESCRIPTION
- Remove -Werror from cc-options

  Currently the build with -Werror fails on my system due to a redundant `-L` path:

  > error: clang: error: argument unused during compilation: '-LD:\\ghcup\\ghc\\9.4.8\\lib\\../mingw/lib' \[-Werror,-Wunused-command-line-argument\]

  Future versions of compilers may break the build with -Werror again just by introducing new warnings.
  
- Upgrade to singletons 3.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chpatrick/clang-pure/27)
<!-- Reviewable:end -->
